### PR TITLE
mm-video-legacy: venc: update allocation-size check for meta-buffer

### DIFF
--- a/msm8974/mm-video-legacy/vidc/venc/src/omx_video_base.cpp
+++ b/msm8974/mm-video-legacy/vidc/venc/src/omx_video_base.cpp
@@ -2618,7 +2618,7 @@ OMX_ERRORTYPE omx_video::allocate_input_meta_buffer(
                     OMX_U32              bytes)
 {
   unsigned index = 0;
-  if(!bufferHdr || bytes != sizeof(encoder_media_buffer_type))
+  if(!bufferHdr || bytes < sizeof(encoder_media_buffer_type))
   {
     DEBUG_PRINT_ERROR("wrong params allocate_input_meta_buffer Hdr %p len %d",
                      bufferHdr,bytes);


### PR DESCRIPTION
Metadata buffer |MetadataBufferType|buffer_handle_t| size can be
8 or 16 bytes on 32-bit or 64-bit respectively. Update the check
which always assumes 32-bit size.

bug: 22487196

Based on:
https://android.googlesource.com/platform/hardware/qcom/media/+/7d6e61888e010bbe79878827a3a593699e9a2595